### PR TITLE
Update avx512fintrin.h

### DIFF
--- a/lib/Headers/avx512fintrin.h
+++ b/lib/Headers/avx512fintrin.h
@@ -1316,7 +1316,7 @@ _mm512_loadu_ps(float const *__p)
 }
 
 static __inline __m512 __attribute__((__always_inline__, __nodebug__))
-_mm512_load_ps(double const *__p)
+_mm512_load_ps(float const *__p)
 {
   return (__m512) __builtin_ia32_loadaps512_mask ((const __v16sf *)__p,
                                                   (__v16sf)
@@ -1325,7 +1325,7 @@ _mm512_load_ps(double const *__p)
 }
 
 static __inline __m512d __attribute__((__always_inline__, __nodebug__))
-_mm512_load_pd(float const *__p)
+_mm512_load_pd(double const *__p)
 {
   return (__m512d) __builtin_ia32_loadapd512_mask ((const __v8df *)__p,
                                                    (__v8df)


### PR DESCRIPTION
Obvious type error on pointers. Surprised the other loads and stores are 
taking (void *) as this will force an odd typecast on correctly typed arguments.
