### PR TITLE
Fix Bug 24877 - clang-format AllowShortCaseLabelsOnASingleLine

### DIFF
--- a/lib/Format/UnwrappedLineFormatter.cpp
+++ b/lib/Format/UnwrappedLineFormatter.cpp
@@ -307,6 +307,8 @@ private:
       if (Line->First->isOneOf(tok::kw_if, tok::kw_for, tok::kw_switch,
                                tok::kw_while, tok::comment))
         return 0;
+      if (Line->Last->is(tok::comment))
+	return 0;
       Length += I[1 + NumStmts]->Last->TotalLength + 1; // 1 for the space.
     }
     if (NumStmts == 0 || NumStmts == 3 || Length > Limit)

--- a/unittests/Format/FormatTest.cpp
+++ b/unittests/Format/FormatTest.cpp
@@ -756,6 +756,9 @@ TEST_F(FormatTest, ShortCaseLabels) {
                "case 7:\n"
                "  // comment\n"
                "  return;\n"
+	       "case 8:\n"
+	       "  x = 8; // comment\n"
+	       "  break;\n"
                "default: y = 1; break;\n"
                "}",
                Style);


### PR DESCRIPTION
https://llvm.org/bugs/show_bug.cgi?id=24877