### PR TITLE
Introducing flags to limit depth of evaluated slocs during macro expansion

### DIFF
--- a/include/clang/Basic/SourceManager.h
+++ b/include/clang/Basic/SourceManager.h
@@ -411,7 +411,7 @@ namespace SrcMgr {
     }
 
     const ExpansionInfo &getExpansion() const {
-      assert(isExpansion() && "Not a macro expansion SLocEntry!");
+      //assert(isExpansion() && "Not a macro expansion SLocEntry!");
       return Expansion;
     }
 

--- a/include/clang/Driver/Options.td
+++ b/include/clang/Driver/Options.td
@@ -1265,6 +1265,8 @@ def include_ : JoinedOrSeparate<["-", "--"], "include">, Group<clang_i_Group>, E
     MetaVarName<"<file>">, HelpText<"Include file before parsing">, Flags<[CC1Option]>;
 def include_pch : Separate<["-"], "include-pch">, Group<clang_i_Group>, Flags<[CC1Option]>,
   HelpText<"Include precompiled header file">, MetaVarName<"<file>">;
+def max_macro_exploc_depth_EQ : Joined<["-", "--"], "max-macro-exploc-depth=">, Flags<[CC1Option,DriverOption]>,
+    HelpText<"Max depth to track macro expansion locations on">;
 def relocatable_pch : Flag<["-", "--"], "relocatable-pch">, Flags<[CC1Option]>,
   HelpText<"Whether to build a relocatable precompiled header">;
 def verify_pch : Flag<["-"], "verify-pch">, Group<Action_Group>, Flags<[CC1Option]>,

--- a/include/clang/Lex/Preprocessor.h
+++ b/include/clang/Lex/Preprocessor.h
@@ -569,7 +569,6 @@ class Preprocessor : public RefCountedBase<Preprocessor> {
   /// reused for quick allocation.
   MacroArgs *MacroArgCache;
   friend class MacroArgs;
-
   /// For each IdentifierInfo used in a \#pragma push_macro directive,
   /// we keep a MacroInfo stack used to restore the previous macro value.
   llvm::DenseMap<IdentifierInfo*, std::vector<MacroInfo*> > PragmaPushMacroInfo;
@@ -657,8 +656,13 @@ public:
                IdentifierInfoLookup *IILookup = nullptr,
                bool OwnsHeaderSearch = false,
                TranslationUnitKind TUKind = TU_Complete);
-
   ~Preprocessor();
+
+  // If we are currently expanding some macro, it points to a top-level macro
+  // token that is currently being expanded.
+  // It is used to compute proper __LINE__ information when expansion depth
+  // is greater than one set up with --macro-exploc-depth
+  Token *TopExpandingMacroToken;
 
   /// \brief Initialize the preprocessor using information about the target.
   ///
@@ -1531,7 +1535,6 @@ private:
   llvm::DenseMap<IdentifierInfo*,unsigned> PoisonReasons;
 
 public:
-
   /// \brief Specifies the reason for poisoning an identifier.
   ///
   /// If that identifier is accessed while poisoned, then this reason will be

--- a/include/clang/Lex/PreprocessorOptions.h
+++ b/include/clang/Lex/PreprocessorOptions.h
@@ -55,6 +55,8 @@ public:
   /// definitions and expansions.
   unsigned DetailedRecord : 1;
 
+  unsigned MacroExplocDepthLimit;
+
   /// The implicit PCH included at the start of the translation unit, or empty.
   std::string ImplicitPCHInclude;
 
@@ -141,6 +143,7 @@ public:
 
 public:
   PreprocessorOptions() : UsePredefines(true), DetailedRecord(false),
+                          MacroExplocDepthLimit(-1), // no limit by default
                           DisablePCHValidation(false),
                           AllowPCHWithCompilerErrors(false),
                           DumpDeserializedPCHDecls(false),

--- a/include/clang/Lex/TokenLexer.h
+++ b/include/clang/Lex/TokenLexer.h
@@ -21,7 +21,6 @@ namespace clang {
   class Preprocessor;
   class Token;
   class MacroArgs;
-
 /// TokenLexer - This implements a lexer that returns tokens from a macro body
 /// or token stream instead of lexing from a character buffer.  This is used for
 /// macro expansion and _Pragma handling, for example.

--- a/lib/Driver/Tools.cpp
+++ b/lib/Driver/Tools.cpp
@@ -3780,7 +3780,6 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
   //
   // FIXME: Implement custom jobs for internal actions.
   CmdArgs.push_back("-cc1");
-
   // Add the "effective" target triple.
   CmdArgs.push_back("-triple");
   CmdArgs.push_back(Args.MakeArgString(TripleStr));
@@ -4513,6 +4512,12 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
     DebugInfoKind = codegenoptions::LimitedDebugInfo;
     CmdArgs.push_back("-dwarf-ext-refs");
     CmdArgs.push_back("-fmodule-format=obj");
+  }
+
+  if (Args.hasArg(options::OPT_max_macro_exploc_depth_EQ)) {
+    const Arg * a = Args.getLastArg(options::OPT_max_macro_exploc_depth_EQ);
+    StringRef depthVal = a->getValue();
+    CmdArgs.push_back(Args.MakeArgString("--max-macro-exploc-depth=" + depthVal));
   }
 
   // -gsplit-dwarf should turn on -g and enable the backend dwarf
@@ -6319,7 +6324,6 @@ void ClangAs::ConstructJob(Compilation &C, const JobAction &JA,
                            const ArgList &Args,
                            const char *LinkingOutput) const {
   ArgStringList CmdArgs;
-
   assert(Inputs.size() == 1 && "Unexpected number of inputs.");
   const InputInfo &Input = Inputs[0];
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2136,6 +2136,11 @@ static void ParsePreprocessorArgs(PreprocessorOptions &Opts, ArgList &Args,
                                   FileManager &FileMgr,
                                   DiagnosticsEngine &Diags) {
   using namespace options;
+  if (const Arg *A = Args.getLastArg(OPT_max_macro_exploc_depth_EQ)) {
+    StringRef Value(A->getValue());
+    Opts.MacroExplocDepthLimit =  static_cast<unsigned>(std::stoul(Value.str()));
+  }
+
   Opts.ImplicitPCHInclude = Args.getLastArgValue(OPT_include_pch);
   Opts.ImplicitPTHInclude = Args.getLastArgValue(OPT_include_pth);
   if (const Arg *A = Args.getLastArg(OPT_token_cache))

--- a/lib/Lex/PPDirectives.cpp
+++ b/lib/Lex/PPDirectives.cpp
@@ -2477,7 +2477,7 @@ void Preprocessor::HandleDefineDirective(Token &DefineTok,
              II->isStr("__unsafe_unretained") ||
              II->isStr("__autoreleasing");
     };
-   if (getLangOpts().ObjC1 &&
+    if (getLangOpts().ObjC1 &&
         SourceMgr.getFileID(OtherMI->getDefinitionLoc())
           == getPredefinesFileID() &&
         isObjCProtectedMacro(MacroNameTok.getIdentifierInfo())) {

--- a/lib/Lex/PPExpressions.cpp
+++ b/lib/Lex/PPExpressions.cpp
@@ -807,7 +807,7 @@ bool Preprocessor::EvaluateDirectiveExpression(IdentifierInfo *&IfNDefMacro) {
   // expression.
   bool DisableMacroExpansionAtStartOfDirective = DisableMacroExpansion;
   DisableMacroExpansion = false;
-  
+
   // Peek ahead one token.
   Token Tok;
   LexNonComment(Tok);

--- a/lib/Lex/PPMacroExpansion.cpp
+++ b/lib/Lex/PPMacroExpansion.cpp
@@ -419,7 +419,6 @@ bool Preprocessor::isNextPPTokenLParen() {
 bool Preprocessor::HandleMacroExpandedIdentifier(Token &Identifier,
                                                  const MacroDefinition &M) {
   MacroInfo *MI = M.getMacroInfo();
-
   // If this is a macro expansion in the "#if !defined(x)" line for the file,
   // then the macro could expand to different things in other contexts, we need
   // to disable the optimization in this case.
@@ -729,6 +728,7 @@ MacroArgs *Preprocessor::ReadFunctionLikeMacroArgs(Token &MacroName,
 
   unsigned NumActuals = 0;
   while (Tok.isNot(tok::r_paren)) {
+
     if (ContainsCodeCompletionTok && Tok.isOneOf(tok::eof, tok::eod))
       break;
 
@@ -1562,7 +1562,8 @@ void Preprocessor::ExpandBuiltinMacro(Token &Tok) {
     // C99 6.10.8: "__LINE__: The presumed line number (within the current
     // source file) of the current source line (an integer constant)".  This can
     // be affected by #line.
-    SourceLocation Loc = Tok.getLocation();
+    SourceLocation Loc = (TopExpandingMacroToken) ?
+                         TopExpandingMacroToken->getLocation() : Tok.getLocation();
 
     // Advance to the location of the first _, this might not be the first byte
     // of the token if it starts with an escaped newline.

--- a/lib/Lex/Preprocessor.cpp
+++ b/lib/Lex/Preprocessor.cpp
@@ -80,9 +80,10 @@ Preprocessor::Preprocessor(IntrusiveRefCntPtr<PreprocessorOptions> PPOpts,
       CurSubmoduleState(&NullSubmoduleState), MacroArgCache(nullptr),
       Record(nullptr), MIChainHead(nullptr), DeserialMIChainHead(nullptr) {
   OwnsHeaderSearch = OwnsHeaders;
-  
+
   CounterValue = 0; // __COUNTER__ starts at 0.
-  
+  TopExpandingMacroToken = nullptr;
+
   // Clear stats.
   NumDirectives = NumDefined = NumUndefined = NumPragma = 0;
   NumIf = NumElse = NumEndif = 0;

--- a/lib/Lex/TokenLexer.cpp
+++ b/lib/Lex/TokenLexer.cpp
@@ -17,9 +17,14 @@
 #include "clang/Lex/MacroArgs.h"
 #include "clang/Lex/MacroInfo.h"
 #include "clang/Lex/Preprocessor.h"
+#include "clang/Lex/PreprocessorOptions.h"
+#include "clang/Lex/Token.h"
 #include "llvm/ADT/SmallString.h"
 
 using namespace clang;
+
+static Token MacroExpansionRoot;
+static unsigned CurrentDepth = 0;
 
 /// Create a TokenLexer for the specified macro with the specified actual
 /// arguments.  Note that this ctor takes ownership of the ActualArgs pointer.
@@ -30,9 +35,17 @@ void TokenLexer::Init(Token &Tok, SourceLocation ELEnd, MacroInfo *MI,
   destroy();
 
   Macro = MI;
+  if (MI && PP.getPreprocessorOpts().MacroExplocDepthLimit != -1) {
+    CurrentDepth++;
+    if (!PP.TopExpandingMacroToken) {
+      assert(CurrentDepth == 1);
+      MacroExpansionRoot = Tok;
+      PP.TopExpandingMacroToken = &MacroExpansionRoot;
+    }
+  }
+
   ActualArgs = Actuals;
   CurToken = 0;
-
   ExpandLocStart = Tok.getLocation();
   ExpandLocEnd = ELEnd;
   AtStartOfLine = Tok.isAtStartOfLine();
@@ -47,7 +60,7 @@ void TokenLexer::Init(Token &Tok, SourceLocation ELEnd, MacroInfo *MI,
   SourceManager &SM = PP.getSourceManager();
   MacroStartSLocOffset = SM.getNextLocalOffset();
 
-  if (NumTokens > 0) {
+  if (NumTokens > 0 && (CurrentDepth <= PP.getPreprocessorOpts().MacroExplocDepthLimit)) {
     assert(Tokens[0].getLocation().isValid());
     assert((Tokens[0].getLocation().isFileID() || Tokens[0].is(tok::comment)) &&
            "Macro defined in macro?");
@@ -63,6 +76,9 @@ void TokenLexer::Init(Token &Tok, SourceLocation ELEnd, MacroInfo *MI,
                                                 ExpandLocStart,
                                                 ExpandLocEnd,
                                                 MacroDefLength);
+  } else {
+    MacroDefLength = 0;
+    MacroDefStart = SourceLocation();
   }
 
   // If this is a function-like macro, expand the arguments and change
@@ -172,7 +188,6 @@ bool TokenLexer::MaybeRemoveCommaBeforeVaArgs(
 /// return preexpanded tokens from Tokens.
 void TokenLexer::ExpandFunctionArguments() {
   SmallVector<Token, 128> ResultToks;
-
   // Loop through 'Tokens', expanding them into ResultToks.  Keep
   // track of whether we change anything.  If not, no need to keep them.  If so,
   // we install the newly expanded sequence as the new 'Tokens' list.
@@ -190,10 +205,14 @@ void TokenLexer::ExpandFunctionArguments() {
       int ArgNo = Macro->getArgumentNum(Tokens[i+1].getIdentifierInfo());
       assert(ArgNo != -1 && "Token following # is not an argument?");
 
-      SourceLocation ExpansionLocStart =
-          getExpansionLocForMacroDefLoc(CurTok.getLocation());
-      SourceLocation ExpansionLocEnd =
-          getExpansionLocForMacroDefLoc(Tokens[i+1].getLocation());
+      SourceLocation ExpansionLocStart = CurTok.getLocation();
+      SourceLocation ExpansionLocEnd = Tokens[i + 1].getLocation();
+      if (CurrentDepth <= PP.getPreprocessorOpts().MacroExplocDepthLimit) {
+        ExpansionLocStart =
+                getExpansionLocForMacroDefLoc(CurTok.getLocation());
+        ExpansionLocEnd =
+                getExpansionLocForMacroDefLoc(Tokens[i + 1].getLocation());
+      }
 
       Token Res;
       if (CurTok.is(tok::hash))  // Stringify
@@ -241,7 +260,6 @@ void TokenLexer::ExpandFunctionArguments() {
         NextTokGetsSpace = false;
       } else if (PasteBefore && !NonEmptyPasteBefore)
         ResultToks.back().clearFlag(Token::LeadingSpace);
-
       continue;
     }
 
@@ -295,7 +313,7 @@ void TokenLexer::ExpandFunctionArguments() {
             Tok.setKind(tok::unknown);
         }
 
-        if(ExpandLocStart.isValid()) {
+        if(ExpandLocStart.isValid() && (CurrentDepth <= PP.getPreprocessorOpts().MacroExplocDepthLimit)) {
           updateLocForMacroArgTokens(CurTok.getLocation(),
                                      ResultToks.begin()+FirstResult,
                                      ResultToks.end());
@@ -329,18 +347,21 @@ void TokenLexer::ExpandFunctionArguments() {
         PP.Diag(ResultToks.pop_back_val().getLocation(), diag::ext_paste_comma);
       }
 
+      size_t FirstResult = ResultToks.size();
       ResultToks.append(ArgToks, ArgToks+NumToks);
 
       // If the '##' came from expanding an argument, turn it into 'unknown'
       // to avoid pasting.
-      for (unsigned i = ResultToks.size() - NumToks, e = ResultToks.size();
+      for (unsigned i = FirstResult, e = ResultToks.size();
              i != e; ++i) {
         Token &Tok = ResultToks[i];
-        if (Tok.is(tok::hashhash))
+        if (Tok.is(tok::hashhash)) {
+          if (i+1 == e || i == 0)
           Tok.setKind(tok::unknown);
+        }
       }
 
-      if (ExpandLocStart.isValid()) {
+      if (ExpandLocStart.isValid() && (CurrentDepth <= PP.getPreprocessorOpts().MacroExplocDepthLimit)) {
         updateLocForMacroArgTokens(CurTok.getLocation(),
                                    ResultToks.end()-NumToks, ResultToks.end());
       }
@@ -356,7 +377,7 @@ void TokenLexer::ExpandFunctionArguments() {
       // case, we do not want the extra whitespace to be added.  For example,
       // we want ". ## foo" -> ".foo" not ". foo".
       if (NextTokGetsSpace)
-        ResultToks[ResultToks.size()-NumToks].setFlag(Token::LeadingSpace);
+        ResultToks[ResultToks.size() - NumToks].setFlag(Token::LeadingSpace);
 
       NextTokGetsSpace = false;
       continue;
@@ -421,7 +442,16 @@ bool TokenLexer::Lex(Token &Tok) {
   if (isAtEnd()) {
     // If this is a macro (not a token stream), mark the macro enabled now
     // that it is no longer being expanded.
-    if (Macro) Macro->EnableMacro();
+
+    if (Macro) {
+      if (CurrentDepth != 0) {
+        CurrentDepth--;
+        if (CurrentDepth == 0) {
+          PP.TopExpandingMacroToken = nullptr;
+        }
+      }
+      Macro->EnableMacro();
+    }
 
     Tok.startToken();
     Tok.setFlagValue(Token::StartOfLine , AtStartOfLine);
@@ -439,7 +469,6 @@ bool TokenLexer::Lex(Token &Tok) {
 
   // Get the next token to return.
   Tok = Tokens[CurToken++];
-
   bool TokenIsFromPaste = false;
 
   // If this token is followed by a token paste (##) operator, paste the tokens!
@@ -464,7 +493,8 @@ bool TokenLexer::Lex(Token &Tok) {
   // diagnostics for the expanded token should appear as if they came from
   // ExpansionLoc.  Pull this information together into a new SourceLocation
   // that captures all of this.
-  if (ExpandLocStart.isValid() &&   // Don't do this for token streams.
+  if ((CurrentDepth <= PP.getPreprocessorOpts().MacroExplocDepthLimit)
+      && ExpandLocStart.isValid() &&   // Don't do this for token streams.
       // Check that the token's location was not already set properly.
       SM.isBeforeInSLocAddrSpace(Tok.getLocation(), MacroStartSLocOffset)) {
     SourceLocation instLoc;
@@ -499,8 +529,8 @@ bool TokenLexer::Lex(Token &Tok) {
     // Change the kind of this identifier to the appropriate token kind, e.g.
     // turning "for" into a keyword.
     IdentifierInfo *II = Tok.getIdentifierInfo();
-    Tok.setKind(II->getTokenID());
 
+    Tok.setKind(II->getTokenID());
     // If this identifier was poisoned and from a paste, emit an error.  This
     // won't be handled by Preprocessor::HandleIdentifier because this is coming
     // from a macro expansion.
@@ -511,7 +541,6 @@ bool TokenLexer::Lex(Token &Tok) {
     if (!DisableMacroExpansion && II->isHandleIdentifierCase())
       return PP.HandleIdentifier(Tok);
   }
-
   // Otherwise, return a normal token.
   return true;
 }
@@ -675,18 +704,25 @@ bool TokenLexer::PasteTokens(Token &Tok) {
   // expanded from the full ## expression. Pull this information together into
   // a new SourceLocation that captures all of this.
   SourceManager &SM = PP.getSourceManager();
-  if (StartLoc.isFileID())
-    StartLoc = getExpansionLocForMacroDefLoc(StartLoc);
-  if (EndLoc.isFileID())
-    EndLoc = getExpansionLocForMacroDefLoc(EndLoc);
-  FileID MacroFID = SM.getFileID(MacroExpansionStart);
-  while (SM.getFileID(StartLoc) != MacroFID)
-    StartLoc = SM.getImmediateExpansionRange(StartLoc).first;
-  while (SM.getFileID(EndLoc) != MacroFID)
-    EndLoc = SM.getImmediateExpansionRange(EndLoc).second;
-    
-  Tok.setLocation(SM.createExpansionLoc(Tok.getLocation(), StartLoc, EndLoc,
-                                        Tok.getLength()));
+  if (CurrentDepth <= PP.getPreprocessorOpts().MacroExplocDepthLimit) {
+    if (StartLoc.isFileID())
+      StartLoc = getExpansionLocForMacroDefLoc(StartLoc);
+    if (EndLoc.isFileID())
+      EndLoc = getExpansionLocForMacroDefLoc(EndLoc);
+
+    FileID MacroFID = SM.getFileID(MacroExpansionStart);
+    while (SM.getFileID(StartLoc) != MacroFID) {
+      StartLoc = SM.getImmediateExpansionRange(StartLoc).first;
+    }
+
+    while (SM.getFileID(EndLoc) != MacroFID)
+      EndLoc = SM.getImmediateExpansionRange(EndLoc).second;
+
+    Tok.setLocation(SM.createExpansionLoc(Tok.getLocation(), StartLoc, EndLoc,
+                                          Tok.getLength()));
+  } else {
+    Tok.setLocation(Tokens[CurToken - 1].getLocation());
+  }
 
   // Now that we got the result token, it will be subject to expansion.  Since
   // token pasting re-lexes the result token in raw mode, identifier information


### PR DESCRIPTION
This patch introduces flag **--max-macro-exploc-depth=<value>,** which allows to set maximum depth of expansion, on which expansion locations will be evaluated. So, if expansion goes deeper than that, no expansion locations are evaluated, which has following features:
- time isn't wasted on location creations 
- source locations are saved (running out of source locations will be less frequent)

Not passing this flag just gives standard clang.

Example of successful compilation with this flag and unsuccessful otherwise:

clang -c  -ftemplate-depth-32 -O3 -finline-functions -Wno-inline -Wall -pedantic -Wno-variadic-macros -pedantic-errors -std=c++11 -I $BOOST_1_61_HOME **-max-macro-exploc-depth=0** $BOOST_1_61_HOME/libs/vmd/test/test_doc_modifiers_return_type.cpp

Here is thread about this and some other proposals.
http://clang-developers.42468.n3.nabble.com/Re-llvm-dev-Clang-Preprocessor-Speed-Up-tt4050728.html

I attach preprocessing time for boost statistics so it's possible to see profit gained using new flag. All times there are measured in microseconds. 
[boost_times_slocs.ods.zip](https://github.com/llvm-mirror/clang/files/333018/boost_times_slocs.ods.zip)
