### PR TITLE
Expose clang_getCursorResultType in python bindings

### DIFF
--- a/bindings/python/clang/cindex.py
+++ b/bindings/python/clang/cindex.py
@@ -1528,6 +1528,16 @@ class Cursor(Structure):
         return AccessSpecifier.from_id(self._access_specifier)
 
     @property
+    def cursor_result_type(self):
+        """
+        Retrieve the return Type (if any) of the entity pointed at by the cursor.
+        """
+        if not hasattr(self, '_cursor_result_type'):
+            self._cursor_result_type = conf.lib.clang_getCursorResultType(self)
+
+        return self._cursor_result_type
+
+    @property
     def type(self):
         """
         Retrieve the Type (if any) of the entity pointed at by the cursor.
@@ -3343,6 +3353,11 @@ functionList = [
    [Cursor],
    Cursor,
    Cursor.from_result),
+
+  ("clang_getCursorResultType",
+   [Cursor],
+   Type,
+   Type.from_result),
 
   ("clang_getCursorReferenceNameRange",
    [Cursor, c_uint, c_uint],


### PR DESCRIPTION
This is needed in order to get the return type of an ObjectiveC method:

http://clang.llvm.org/doxygen/group__CINDEX__TYPES.html#ga6995a2d6352e7136868574b299005a63
