### PR TITLE
[clang-format] add fallback style option "fail"

### DIFF
--- a/docs/ClangFormat.rst
+++ b/docs/ClangFormat.rst
@@ -42,6 +42,7 @@ to format C/C++/Obj-C code.
                                 -style=file, but can not find the .clang-format
                                 file to use.
                                 Use -fallback-style=none to skip formatting.
+                                Use -fallback-style=fail to exit with an error.
     -i                        - Inplace edit <file>s, if specified.
     -length=<uint>            - Format a range of this length (in bytes).
                                 Multiple ranges can be formatted by specifying

--- a/lib/Format/Format.cpp
+++ b/lib/Format/Format.cpp
@@ -737,7 +737,7 @@ bool getPredefinedStyle(StringRef Name, FormatStyle::LanguageKind Language,
     *Style = getWebKitStyle();
   } else if (Name.equals_lower("gnu")) {
     *Style = getGNUStyle();
-  } else if (Name.equals_lower("none")) {
+  } else if (Name.equals_lower("none") || Name.equals_lower("fail")) {
     *Style = getNoStyle();
   } else {
     return false;
@@ -1977,7 +1977,12 @@ llvm::Expected<FormatStyle> getStyle(StringRef StyleName, StringRef FileName,
     return make_string_error("Configuration file(s) do(es) not support " +
                              getLanguageName(Style.Language) + ": " +
                              UnsuitableConfigFiles);
-  return FallbackStyle;
+
+  if (!FallbackStyleName.equals_lower("fail")) {
+    return FallbackStyle;
+  } else {
+    return make_string_error("Configuration file not found.");
+  }
 }
 
 } // namespace format

--- a/tools/clang-format/ClangFormat.cpp
+++ b/tools/clang-format/ClangFormat.cpp
@@ -68,7 +68,8 @@ FallbackStyle("fallback-style",
                        "fallback in case clang-format is invoked with\n"
                        "-style=file, but can not find the .clang-format\n"
                        "file to use.\n"
-                       "Use -fallback-style=none to skip formatting."),
+                       "Use -fallback-style=none to skip formatting.\n"
+                       "Use -fallback-style=fail to exit with an error."),
               cl::init("LLVM"), cl::cat(ClangFormatCategory));
 
 static cl::opt<std::string>

--- a/unittests/Format/FormatTest.cpp
+++ b/unittests/Format/FormatTest.cpp
@@ -11465,7 +11465,12 @@ TEST(FormatStyle, GetStyleOfFile) {
   ASSERT_TRUE((bool)Style2);
   ASSERT_EQ(*Style2, getNoStyle());
 
-  // Test 2.3: format if config is found with no based style while fallback is
+  // Test 2.3: no format on 'fail' fallback style.
+  Style2 = getStyle("file", "/b/test.cpp", "fail", "", &FS);
+  ASSERT_FALSE((bool)Style2);
+  llvm::consumeError(Style2.takeError());
+
+  // Test 2.4: format if config is found with no based style while fallback is
   // 'none'.
   ASSERT_TRUE(FS.addFile("/b/.clang-format", 0,
                          llvm::MemoryBuffer::getMemBuffer("IndentWidth: 2")));
@@ -11473,7 +11478,7 @@ TEST(FormatStyle, GetStyleOfFile) {
   ASSERT_TRUE((bool)Style2);
   ASSERT_EQ(*Style2, getLLVMStyle());
 
-  // Test 2.4: format if yaml with no based style, while fallback is 'none'.
+  // Test 2.5: format if yaml with no based style, while fallback is 'none'.
   Style2 = getStyle("{}", "a.h", "none", "", &FS);
   ASSERT_TRUE((bool)Style2);
   ASSERT_EQ(*Style2, getLLVMStyle());


### PR DESCRIPTION
Allow user to identify if `-style=file` fails and clang-format is going to fallback.