### PR TITLE
Update AnalysisDeclContext.cpp

### DIFF
--- a/lib/Analysis/AnalysisDeclContext.cpp
+++ b/lib/Analysis/AnalysisDeclContext.cpp
@@ -95,8 +95,8 @@ Stmt *AnalysisDeclContext::getBody(bool &IsAutosynthesized) const {
     if (auto *CoroBody = dyn_cast_or_null<CoroutineBodyStmt>(Body))
       Body = CoroBody->getBody();
     if (Manager && Manager->synthesizeBodies()) {
-      Stmt *SynthesizedBody =
-          getBodyFarm(getASTContext(), Manager->Injector.get()).getBody(FD);
+BodyFarm bf = BodyFarm(getASTContext(), Manager->Injector.get());
+bf.getBody(FD)
       if (SynthesizedBody) {
         Body = SynthesizedBody;
         IsAutosynthesized = true;
@@ -107,8 +107,8 @@ Stmt *AnalysisDeclContext::getBody(bool &IsAutosynthesized) const {
   else if (const ObjCMethodDecl *MD = dyn_cast<ObjCMethodDecl>(D)) {
     Stmt *Body = MD->getBody();
     if (Manager && Manager->synthesizeBodies()) {
-      Stmt *SynthesizedBody =
-          getBodyFarm(getASTContext(), Manager->Injector.get()).getBody(MD);
+BodyFarm bf = BodyFarm(getASTContext(), Manager->Injector.get());
+bf.getBody(FD)
       if (SynthesizedBody) {
         Body = SynthesizedBody;
         IsAutosynthesized = true;


### PR DESCRIPTION
The static BodyFarm causes some problems. Sometimes, when analyzing the content twice,it exists with core error ,segment fault or anything else. The static var may improve the performance，but not the best choice here. If you want to know more about the scenery, email me.