### PR TITLE
fix unsaved_files_array TypeError in reparse method

### DIFF
--- a/bindings/python/clang/cindex.py
+++ b/bindings/python/clang/cindex.py
@@ -2983,8 +2983,8 @@ class TranslationUnit(ClangObject):
                     print(value)
                 if not isinstance(value, str):
                     raise TypeError('Unexpected unsaved file contents.')
-                unsaved_files_array[i].name = name
-                unsaved_files_array[i].contents = value
+                unsaved_files_array[i].name = b(name)
+                unsaved_files_array[i].contents = b(value)
                 unsaved_files_array[i].length = len(value)
         ptr = conf.lib.clang_reparseTranslationUnit(self, len(unsaved_files),
                 unsaved_files_array, options)


### PR DESCRIPTION
In reparse method, the way unsaved_files_array is filled is not consistent with from_source and codeComplete methods and raises TypeError when passed a python3 unicode str.