### PR TITLE
Added switch to suppress diagnostic notes: -Wno-clang-notes

### DIFF
--- a/include/clang/Basic/Diagnostic.h
+++ b/include/clang/Basic/Diagnostic.h
@@ -215,6 +215,9 @@ private:
   // Suppress all diagnostics.
   bool SuppressAllDiagnostics = false;
 
+  // Suppress all notes.
+  bool SuppressAllNotes = true;
+
   // Elide common types of templates.
   bool ElideType = true;
 
@@ -633,6 +636,12 @@ public:
     SuppressAllDiagnostics = Val;
   }
   bool getSuppressAllDiagnostics() const { return SuppressAllDiagnostics; }
+
+  /// Suppress all notes, to silence the front end when the user has a brain
+  void setSuppressAllNotes(bool Val = true) {
+    SuppressAllNotes = Val;
+  }
+  bool getSuppressAllNotes() const { return SuppressAllNotes; }
 
   /// Set type eliding, to skip outputting same types occurring in
   /// template types.

--- a/lib/Basic/DiagnosticIDs.cpp
+++ b/lib/Basic/DiagnosticIDs.cpp
@@ -647,6 +647,9 @@ bool DiagnosticIDs::ProcessDiag(DiagnosticsEngine &Diag) const {
   if (Diag.SuppressAllDiagnostics)
     return false;
 
+  if (Diag.SuppressAllNotes && DiagLevel == DiagnosticIDs::Note)
+    return false;
+
   if (DiagLevel != DiagnosticIDs::Note) {
     // Record that a fatal error occurred only when we see a second
     // non-note diagnostic. This allows notes to be attached to the

--- a/lib/Basic/Warnings.cpp
+++ b/lib/Basic/Warnings.cpp
@@ -44,6 +44,7 @@ void clang::ProcessWarningOptions(DiagnosticsEngine &Diags,
                                   const DiagnosticOptions &Opts,
                                   bool ReportDiags) {
   Diags.setSuppressSystemWarnings(true);  // Default to -Wno-system-headers
+  Diags.setSuppressAllNotes(false);		  // Default to -Wclang-notes
   Diags.setIgnoreAllWarnings(Opts.IgnoreWarnings);
   Diags.setShowOverloads(Opts.getShowOverloads());
 
@@ -105,6 +106,13 @@ void clang::ProcessWarningOptions(DiagnosticsEngine &Diags,
       // diagnostic to a warning, if -Wno-foo, map it to ignore.
       diag::Severity Mapping =
           isPositive ? diag::Severity::Warning : diag::Severity::Ignored;
+
+	  // -Wno-clang-notes
+      if (Opt == "clang-notes") {
+        if (SetDiagnostic)
+          Diags.setSuppressAllNotes(!isPositive);
+        continue;
+      }
 
       // -Wsystem-headers is a special case, not driven by the option table.  It
       // cannot be controlled with -Werror.


### PR DESCRIPTION
If you are an accomplished programmer and you have a brain, the bazillion lines of "notes" produced by the compiler are completely unhelpful. The notes clutter the output with identically poor/misleading information and make it very hard to find the real error.

This option suppresses those notes. It is not enabled by default, so clang behaves "normally" without the switch.