### PR TITLE
Update quiet mode in git-clang-format

### DIFF
--- a/tools/clang-format/git-clang-format
+++ b/tools/clang-format/git-clang-format
@@ -147,8 +147,9 @@ def main():
       print('Running clang-format on the following files:')
       for filename in changed_lines:
         print('    %s' % filename)
-  if not changed_lines and opts.verbose >= 0:
-    print('no modified files to format')
+  if not changed_lines:
+    if opts.verbose >= 0:
+      print('no modified files to format')
     return
   # The computed diff outputs absolute paths, so we must cd before accessing
   # those files.

--- a/tools/clang-format/git-clang-format
+++ b/tools/clang-format/git-clang-format
@@ -147,7 +147,7 @@ def main():
       print('Running clang-format on the following files:')
       for filename in changed_lines:
         print('    %s' % filename)
-  if not changed_lines:
+  if not changed_lines and opts.verbose >= 0:
     print('no modified files to format')
     return
   # The computed diff outputs absolute paths, so we must cd before accessing


### PR DESCRIPTION
Disable output in quiet mode and no modified files.

Quiet mode is very useful for scripting, when you want just the diff format output, or none if not exist.
In case of no modified files, git-clang-format will output to screen even though the `quiet` mode enabled.

This patch changes this behavior, so if `quiet` flag passes in - no output will be available, even if no modified files exists.