### PR TITLE
Made extract_lines strip tabs from the filename

### DIFF
--- a/tools/clang-format/git-clang-format
+++ b/tools/clang-format/git-clang-format
@@ -305,7 +305,7 @@ def extract_lines(patch_file):
     line = convert_string(line)
     match = re.search(r'^\+\+\+\ [^/]+/(.*)', line)
     if match:
-      filename = match.group(1).rstrip('\r\n')
+      filename = match.group(1).rstrip('\r\n\t')
     match = re.search(r'^@@ -[0-9,]+ \+(\d+)(,(\d+))?', line)
     if match:
       start_line = int(match.group(1))


### PR DESCRIPTION
Made extract_lines strip tabs from the filename, to support git diff-index having tabs in the output.

`git diff-index` will return a tab at the end of the filename, for filenames with spaces in the path. This breaks the git-clang-format script if we don't strip the tab out.